### PR TITLE
feat: add condo fee payments with asaas integration

### DIFF
--- a/src/modules/condoFees/application/useCases/AsaasWebhook/AsaasWebhookController.ts
+++ b/src/modules/condoFees/application/useCases/AsaasWebhook/AsaasWebhookController.ts
@@ -1,0 +1,22 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import { Controller, Post, Tags } from '@/shared/http/docs/decorators';
+import { UpdateFeeStatusUseCase } from './UpdateFeeStatusUseCase';
+
+@Tags('Asaas')
+@Controller('asaas')
+export class AsaasWebhookController {
+  @Post('webhook')
+  async handle(req: Request, res: Response): Promise<Response> {
+    const event = req.body?.event;
+    if (event === 'PAYMENT_RECEIVED') {
+      const external = req.body?.payment?.externalReference;
+      if (external) {
+        const useCase = container.resolve(UpdateFeeStatusUseCase);
+        await useCase.execute(external);
+      }
+    }
+    return res.status(200).send();
+  }
+}

--- a/src/modules/condoFees/application/useCases/AsaasWebhook/UpdateFeeStatusUseCase.ts
+++ b/src/modules/condoFees/application/useCases/AsaasWebhook/UpdateFeeStatusUseCase.ts
@@ -1,0 +1,30 @@
+import { inject, injectable } from 'tsyringe';
+import { In } from 'typeorm';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+
+@injectable()
+export class UpdateFeeStatusUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+  ) {}
+
+  async execute(externalReference: string): Promise<void> {
+    const ids = externalReference.split(',').map(id => Number(id));
+    const fees = await this.feesRepository.findAll({
+      where: { id: In(ids) } as any,
+    });
+
+    for (const fee of fees) {
+      await this.feesRepository.update({
+        id: fee.id,
+        status: FeeStatusEnum.PAID,
+      });
+    }
+  }
+}

--- a/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesController.ts
+++ b/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesController.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  Description,
+  CommonResponses,
+} from '@/shared/http/docs/decorators';
+import { GenerateAnnualFeesUseCase } from './GenerateAnnualFeesUseCase';
+import { GenerateFeesDTO } from '@/modules/condoFees/domain/dtos/GenerateFeesDTO';
+
+@Tags('CondoFees')
+@Controller('condo-fees')
+export class GenerateAnnualFeesController {
+  @Post('generate')
+  @Description('Gera as taxas condominiais do ano informado')
+  @Body(GenerateFeesDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(GenerateAnnualFeesUseCase);
+    await useCase.execute(req.body);
+    return res.status(201).json({ message: 'Taxas geradas' });
+  }
+}

--- a/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesUseCase.ts
+++ b/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesUseCase.ts
@@ -1,0 +1,29 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { GenerateFeesDTO } from '@/modules/condoFees/domain/dtos/GenerateFeesDTO';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+
+@injectable()
+export class GenerateAnnualFeesUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+  ) {}
+
+  async execute({ year, amount }: GenerateFeesDTO): Promise<void> {
+    for (let month = 1; month <= 12; month++) {
+      const dueDate = new Date(year, month - 1, 10);
+      await this.feesRepository.create({
+        month,
+        year,
+        amount,
+        status: FeeStatusEnum.PENDING,
+        dueDate,
+      });
+    }
+  }
+}

--- a/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesController.ts
+++ b/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesController.ts
@@ -1,0 +1,27 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  Description,
+  CommonResponses,
+} from '@/shared/http/docs/decorators';
+import { PayFeesDTO } from '@/modules/condoFees/domain/dtos/PayFeesDTO';
+import { PayCondoFeesUseCase } from './PayCondoFeesUseCase';
+
+@Tags('CondoFees')
+@Controller('condo-fees')
+export class PayCondoFeesController {
+  @Post('pay')
+  @Description('Cria cobrança via Asaas para taxas selecionadas')
+  @Body(PayFeesDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(PayCondoFeesUseCase);
+    const result = await useCase.execute(req.body);
+    return res.status(201).json(result);
+  }
+}

--- a/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesUseCase.ts
+++ b/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesUseCase.ts
@@ -1,0 +1,45 @@
+import { inject, injectable } from 'tsyringe';
+import { In } from 'typeorm';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { PayFeesDTO } from '@/modules/condoFees/domain/dtos/PayFeesDTO';
+import { AsaasClient } from '@/shared/providers/asaas/AsaasClient';
+
+@injectable()
+export class PayCondoFeesUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+  ) {}
+
+  async execute({ feeIds }: PayFeesDTO) {
+    const fees = await this.feesRepository.findAll({
+      where: { id: In(feeIds) } as any,
+    });
+
+    const total = fees.reduce((acc, fee) => acc + Number(fee.amount), 0);
+
+    const client = new AsaasClient();
+
+    const payment = await client.createPayment({
+      customer: process.env.ASAAS_CUSTOMER_ID || '',
+      billingType: 'PIX',
+      value: total,
+      description: 'Condo fees',
+      externalReference: feeIds.join(','),
+    });
+
+    for (const fee of fees) {
+      await this.feesRepository.update({
+        id: fee.id,
+        asaasPaymentId: payment.id,
+        externalReference: feeIds.join(','),
+      });
+    }
+
+    return payment;
+  }
+}

--- a/src/modules/condoFees/domain/dtos/GenerateFeesDTO.ts
+++ b/src/modules/condoFees/domain/dtos/GenerateFeesDTO.ts
@@ -1,0 +1,9 @@
+import { IsNumber } from 'class-validator';
+
+export class GenerateFeesDTO {
+  @IsNumber()
+  year!: number;
+
+  @IsNumber()
+  amount!: number;
+}

--- a/src/modules/condoFees/domain/dtos/PayFeesDTO.ts
+++ b/src/modules/condoFees/domain/dtos/PayFeesDTO.ts
@@ -1,0 +1,8 @@
+import { ArrayNotEmpty, IsArray, IsNumber } from 'class-validator';
+
+export class PayFeesDTO {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsNumber({}, { each: true })
+  feeIds!: number[];
+}

--- a/src/modules/condoFees/domain/entities/CondoFee.ts
+++ b/src/modules/condoFees/domain/entities/CondoFee.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+
+@Entity('condo_fees')
+export class CondoFee {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  month!: number;
+
+  @Column()
+  year!: number;
+
+  @Column('decimal')
+  amount!: number;
+
+  @Column({ type: 'varchar', default: FeeStatusEnum.PENDING })
+  status!: FeeStatusEnum;
+
+  @Column({ nullable: true })
+  asaasPaymentId?: string;
+
+  @Column({ nullable: true })
+  externalReference?: string;
+
+  @Column({ type: 'date' })
+  dueDate!: Date;
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  @UpdateDateColumn()
+  updated_at!: Date;
+}

--- a/src/modules/condoFees/domain/enums/fee-status.enum.ts
+++ b/src/modules/condoFees/domain/enums/fee-status.enum.ts
@@ -1,0 +1,4 @@
+export enum FeeStatusEnum {
+  PENDING = 'PENDING',
+  PAID = 'PAID',
+}

--- a/src/modules/condoFees/domain/repositories/ICondoFeesRepository.ts
+++ b/src/modules/condoFees/domain/repositories/ICondoFeesRepository.ts
@@ -1,0 +1,6 @@
+import { CondoFee } from '@/modules/condoFees/domain/entities/CondoFee';
+import { IGenericRepository } from '@/shared/generic/repositories/IGenericRepository';
+
+export const CONDO_FEE_REPOSITORY = 'CONDO_FEE_REPOSITORY';
+
+export interface ICondoFeesRepository extends IGenericRepository<CondoFee> {}

--- a/src/modules/condoFees/infra/repositories/CondoFeesRepository.ts
+++ b/src/modules/condoFees/infra/repositories/CondoFeesRepository.ts
@@ -1,0 +1,19 @@
+import { inject, injectable } from 'tsyringe';
+import { DataSource } from 'typeorm';
+
+import { CondoFee } from '@/modules/condoFees/domain/entities/CondoFee';
+import { GenericRepository } from '@/shared/generic/repositories/GenericRepository';
+import { ICondoFeesRepository } from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+
+@injectable()
+export class CondoFeesRepository
+  extends GenericRepository<CondoFee>
+  implements ICondoFeesRepository
+{
+  constructor(
+    @inject('DataSource')
+    dataSource: DataSource,
+  ) {
+    super(dataSource.getRepository(CondoFee));
+  }
+}

--- a/src/shared/container/respositories.ts
+++ b/src/shared/container/respositories.ts
@@ -4,7 +4,19 @@ import {
   REQUEST_REPOSITORY,
 } from '@/modules/requests/domain/repositories/IRequestsRepository';
 import { RequestsRepository } from '@/modules/requests/infra/repositories/RequestsRepository';
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { CondoFeesRepository } from '@/modules/condoFees/infra/repositories/CondoFeesRepository';
 
 export async function registerRepositoriesProviders(): Promise<void> {
-  container.registerSingleton<IRequestsRepository>(REQUEST_REPOSITORY, RequestsRepository);
+  container.registerSingleton<IRequestsRepository>(
+    REQUEST_REPOSITORY,
+    RequestsRepository,
+  );
+  container.registerSingleton<ICondoFeesRepository>(
+    CONDO_FEE_REPOSITORY,
+    CondoFeesRepository,
+  );
 }

--- a/src/shared/providers/asaas/AsaasClient.ts
+++ b/src/shared/providers/asaas/AsaasClient.ts
@@ -1,0 +1,43 @@
+import 'dotenv/config';
+
+interface AsaasPaymentRequest {
+  customer: string;
+  billingType: 'PIX';
+  value: number;
+  description?: string;
+  externalReference?: string;
+}
+
+interface AsaasPaymentResponse {
+  id: string;
+  status: string;
+  value: number;
+  pixQrCode?: {
+    encodedImage: string;
+    payload: string;
+  };
+}
+
+export class AsaasClient {
+  private baseUrl = process.env.ASAAS_API_URL || 'https://api.asaas.com/v3';
+  private apiKey = process.env.ASAAS_API_KEY || '';
+
+  async createPayment(
+    data: AsaasPaymentRequest,
+  ): Promise<AsaasPaymentResponse> {
+    const response = await fetch(`${this.baseUrl}/payments`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        access_token: this.apiKey,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create payment on Asaas');
+    }
+
+    return response.json();
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931200000-create-table-condo-fees.ts
+++ b/src/shared/providers/typeorm/migrations/1744931200000-create-table-condo-fees.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTableCondoFees1744931200000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'condo_fees',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'month', type: 'int' },
+          { name: 'year', type: 'int' },
+          { name: 'amount', type: 'decimal', precision: 10, scale: 2 },
+          { name: 'status', type: 'varchar' },
+          { name: 'asaasPaymentId', type: 'varchar', isNullable: true },
+          { name: 'externalReference', type: 'varchar', isNullable: true },
+          { name: 'dueDate', type: 'date' },
+          { name: 'created_at', type: 'datetime', default: 'GETDATE()' },
+          { name: 'updated_at', type: 'datetime', default: 'GETDATE()' },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('condo_fees');
+  }
+}


### PR DESCRIPTION
## Summary
- add condo fee module with TypeORM entity and repository
- integrate Asaas API for PIX payments and callback handling
- generate annual condo fees via use case and expose endpoints

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bf774637008330a012774f31c73539