### PR TITLE
feat: manage users and approve expense pix payments

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "helmet": "^8.1.0",
     "ioredis": "^5.6.0",
     "jsonwebtoken": "^9.0.2",
-    "mssql": "^11.0.1",
     "multer": "^1.4.5-lts.2",
     "multer-s3": "^3.0.1",
     "nodemailer": "^6.10.0",
@@ -53,7 +52,8 @@
     "swagger-ui-express": "^4.6.3",
     "tsconfig-paths": "^4.2.0",
     "tsyringe": "^4.9.1",
-    "typeorm": "^0.3.22"
+    "typeorm": "^0.3.22",
+    "mysql2": "^3.11.2"
   },
   "devDependencies": {
     "@babel/cli": "^7.27.0",

--- a/src/@types/express/index.d.ts
+++ b/src/@types/express/index.d.ts
@@ -1,0 +1,11 @@
+import 'express';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    user?: {
+      id: string | number;
+      email: string;
+      isAdmin: boolean;
+    };
+  }
+}

--- a/src/modules/apartments/application/useCases/CreateApartment/CreateApartmentController.ts
+++ b/src/modules/apartments/application/useCases/CreateApartment/CreateApartmentController.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { CreateApartmentDTO } from '@/modules/apartments/domain/dtos/CreateApartmentDTO';
+import { ApartmentResponseDTO } from '@/modules/apartments/domain/dtos/ApartmentResponseDTO';
+import { CreateApartmentUseCase } from './CreateApartmentUseCase';
+
+@Tags('Apartments')
+@Controller('apartments')
+export class CreateApartmentController {
+  @Post()
+  @Description('Create a new apartment')
+  @ApiResponse({
+    statusCode: 201,
+    description: 'Apartment created successfully',
+    dtoClass: ApartmentResponseDTO,
+  })
+  @Body(CreateApartmentDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(CreateApartmentUseCase);
+    const apartment = await useCase.execute(req.body);
+    return res.status(201).json(apartment);
+  }
+}
+

--- a/src/modules/apartments/application/useCases/CreateApartment/CreateApartmentUseCase.ts
+++ b/src/modules/apartments/application/useCases/CreateApartment/CreateApartmentUseCase.ts
@@ -1,0 +1,19 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  IApartmentsRepository,
+  APARTMENT_REPOSITORY,
+} from '@/modules/apartments/domain/repositories/IApartmentsRepository';
+
+@injectable()
+export class CreateApartmentUseCase {
+  constructor(
+    @inject(APARTMENT_REPOSITORY)
+    private apartmentsRepository: IApartmentsRepository,
+  ) {}
+
+  async execute({ number }: { number: string }) {
+    const apartment = await this.apartmentsRepository.create({ number });
+    return apartment;
+  }
+}

--- a/src/modules/apartments/application/useCases/ListApartments/ListApartmentsController.ts
+++ b/src/modules/apartments/application/useCases/ListApartments/ListApartmentsController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ListApartmentsUseCase } from './ListApartmentsUseCase';
+import { ApartmentResponseDTO } from '@/modules/apartments/domain/dtos/ApartmentResponseDTO';
+
+@Tags('Apartments')
+@Controller('apartments')
+export class ListApartmentsController {
+  @Get()
+  @Description('List all apartments')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Apartments listed successfully',
+    dtoClass: [ApartmentResponseDTO],
+  })
+  @CommonResponses()
+  async handle(_req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(ListApartmentsUseCase);
+    const apartments = await useCase.execute();
+    return res.json(apartments);
+  }
+}
+

--- a/src/modules/apartments/application/useCases/ListApartments/ListApartmentsUseCase.ts
+++ b/src/modules/apartments/application/useCases/ListApartments/ListApartmentsUseCase.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  IApartmentsRepository,
+  APARTMENT_REPOSITORY,
+} from '@/modules/apartments/domain/repositories/IApartmentsRepository';
+
+@injectable()
+export class ListApartmentsUseCase {
+  constructor(
+    @inject(APARTMENT_REPOSITORY)
+    private apartmentsRepository: IApartmentsRepository,
+  ) {}
+
+  async execute() {
+    return this.apartmentsRepository.findAll();
+  }
+}

--- a/src/modules/apartments/domain/dtos/ApartmentResponseDTO.ts
+++ b/src/modules/apartments/domain/dtos/ApartmentResponseDTO.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class ApartmentResponseDTO {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  number!: string;
+}
+

--- a/src/modules/apartments/domain/dtos/CreateApartmentDTO.ts
+++ b/src/modules/apartments/domain/dtos/CreateApartmentDTO.ts
@@ -1,0 +1,6 @@
+import { IsString } from 'class-validator';
+
+export class CreateApartmentDTO {
+  @IsString()
+  number!: string;
+}

--- a/src/modules/apartments/domain/entities/Apartment.ts
+++ b/src/modules/apartments/domain/entities/Apartment.ts
@@ -1,0 +1,28 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+import { User } from '@/modules/users/domain/entities/User';
+
+@Entity('apartments')
+export class Apartment {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  number!: string;
+
+  @OneToMany(() => User, (user) => user.apartment)
+  users!: User[];
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  @UpdateDateColumn()
+  updated_at!: Date;
+}

--- a/src/modules/apartments/domain/repositories/IApartmentsRepository.ts
+++ b/src/modules/apartments/domain/repositories/IApartmentsRepository.ts
@@ -1,0 +1,6 @@
+import { Apartment } from '@/modules/apartments/domain/entities/Apartment';
+import { IGenericRepository } from '@/shared/generic/repositories/IGenericRepository';
+
+export const APARTMENT_REPOSITORY = 'APARTMENT_REPOSITORY';
+
+export interface IApartmentsRepository extends IGenericRepository<Apartment> {}

--- a/src/modules/apartments/infra/repositories/ApartmentsRepository.ts
+++ b/src/modules/apartments/infra/repositories/ApartmentsRepository.ts
@@ -1,0 +1,16 @@
+import { inject, injectable } from 'tsyringe';
+import { DataSource } from 'typeorm';
+
+import { Apartment } from '@/modules/apartments/domain/entities/Apartment';
+import { IApartmentsRepository } from '@/modules/apartments/domain/repositories/IApartmentsRepository';
+import { GenericRepository } from '@/shared/generic/repositories/GenericRepository';
+
+@injectable()
+export class ApartmentsRepository
+  extends GenericRepository<Apartment>
+  implements IApartmentsRepository
+{
+  constructor(@inject('DataSource') dataSource: DataSource) {
+    super(dataSource.getRepository(Apartment));
+  }
+}

--- a/src/modules/condoExpenses/application/useCases/ApproveExpense/ApproveExpenseController.ts
+++ b/src/modules/condoExpenses/application/useCases/ApproveExpense/ApproveExpenseController.ts
@@ -1,0 +1,42 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ApproveExpenseUseCase } from './ApproveExpenseUseCase';
+import { IsNumber } from 'class-validator';
+import { ApproveExpenseResponseDTO } from '@/modules/condoExpenses/domain/dtos/ApproveExpenseResponseDTO';
+
+class ApproveExpenseDTO {
+  @IsNumber()
+  userId!: number;
+}
+
+@Tags('CondoExpenses')
+@Controller('condo-expenses')
+export class ApproveExpenseController {
+  @Post(':id/approve')
+  @Description('Approve payment of an expense')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Expense approval recorded',
+    dtoClass: ApproveExpenseResponseDTO,
+  })
+  @Body(ApproveExpenseDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(ApproveExpenseUseCase);
+    const { id } = req.params;
+    const { userId } = req.body;
+    const result = await useCase.execute({ expenseId: Number(id), userId });
+    return res.json(result);
+  }
+}
+

--- a/src/modules/condoExpenses/application/useCases/ApproveExpense/ApproveExpenseUseCase.ts
+++ b/src/modules/condoExpenses/application/useCases/ApproveExpense/ApproveExpenseUseCase.ts
@@ -1,0 +1,59 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  CONDO_EXPENSE_REPOSITORY,
+  ICondoExpensesRepository,
+} from '@/modules/condoExpenses/domain/repositories/ICondoExpensesRepository';
+import {
+  EXPENSE_APPROVAL_REPOSITORY,
+  IExpenseApprovalsRepository,
+} from '@/modules/condoExpenses/domain/repositories/IExpenseApprovalsRepository';
+import { IUsersRepository, USER_REPOSITORY } from '@/modules/users/domain/repositories/IUsersRepository';
+import { AsaasClient } from '@/shared/providers/asaas/AsaasClient';
+
+@injectable()
+export class ApproveExpenseUseCase {
+  constructor(
+    @inject(CONDO_EXPENSE_REPOSITORY)
+    private expensesRepository: ICondoExpensesRepository,
+    @inject(EXPENSE_APPROVAL_REPOSITORY)
+    private approvalsRepository: IExpenseApprovalsRepository,
+    @inject(USER_REPOSITORY)
+    private usersRepository: IUsersRepository,
+  ) {}
+
+  async execute({ expenseId, userId }: { expenseId: number; userId: number }) {
+    const expense = await this.expensesRepository.findById(expenseId);
+    if (!expense) {
+      throw new Error('Expense not found');
+    }
+
+    const user = await this.usersRepository.findById(userId);
+    if (!user) {
+      throw new Error('User not found');
+    }
+
+    const already = await this.approvalsRepository.hasUserApproved(expenseId, userId);
+    if (!already) {
+      await this.approvalsRepository.create({ expenseId, userId });
+    }
+
+    const count = await this.approvalsRepository.countByExpense(expenseId);
+    if (!expense.paid && expense.pixKey && count >= expense.approvalsRequired) {
+      const client = new AsaasClient();
+      await client.payPix({
+        pixKey: expense.pixKey,
+        value: Number(expense.value),
+        description: expense.description,
+      });
+      await this.expensesRepository.update({
+        id: expenseId,
+        paid: true,
+        paidByUserId: userId,
+        paidByApartmentId: user.apartmentId,
+      });
+    }
+
+    return { approvals: count };
+  }
+}

--- a/src/modules/condoExpenses/application/useCases/CreateExpense/CreateExpenseController.ts
+++ b/src/modules/condoExpenses/application/useCases/CreateExpense/CreateExpenseController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  UseMiddleware,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { upload } from '@/shared/http/middlewares/uploadMiddleware';
+import { CreateExpenseUseCase } from './CreateExpenseUseCase';
+import { CreateExpenseDTO } from '@/modules/condoExpenses/domain/dtos/CreateExpenseDTO';
+import { CondoExpenseResponseDTO } from '@/modules/condoExpenses/domain/dtos/CondoExpenseResponseDTO';
+
+@Tags('CondoExpenses')
+@Controller('condo-expenses')
+export class CreateExpenseController {
+  @Post()
+  @Description('Cria uma nova despesa com comprovante opcional')
+  @ApiResponse({
+    statusCode: 201,
+    description: 'Expense created successfully',
+    dtoClass: CondoExpenseResponseDTO,
+  })
+  @Body(CreateExpenseDTO)
+  @UseMiddleware(upload.single('receipt'))
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(CreateExpenseUseCase);
+    const { description, value, date, pixKey, approvalsRequired } = req.body;
+    const receiptUrl = (req.file as any)?.location;
+    const expense = await useCase.execute({
+      description,
+      value: Number(value),
+      date: new Date(date),
+      receiptUrl,
+      pixKey,
+      approvalsRequired: Number(approvalsRequired),
+    });
+    return res.status(201).json(expense);
+  }
+}
+

--- a/src/modules/condoExpenses/application/useCases/CreateExpense/CreateExpenseUseCase.ts
+++ b/src/modules/condoExpenses/application/useCases/CreateExpense/CreateExpenseUseCase.ts
@@ -1,0 +1,41 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  ICondoExpensesRepository,
+  CONDO_EXPENSE_REPOSITORY,
+} from '@/modules/condoExpenses/domain/repositories/ICondoExpensesRepository';
+
+@injectable()
+export class CreateExpenseUseCase {
+  constructor(
+    @inject(CONDO_EXPENSE_REPOSITORY)
+    private expensesRepository: ICondoExpensesRepository,
+  ) {}
+
+  async execute({
+    description,
+    value,
+    date,
+    receiptUrl,
+    pixKey,
+    approvalsRequired,
+  }: {
+    description: string;
+    value: number;
+    date: Date;
+    receiptUrl?: string;
+    pixKey?: string;
+    approvalsRequired: number;
+  }) {
+    const expense = await this.expensesRepository.create({
+      description,
+      value,
+      date,
+      receiptUrl,
+      pixKey,
+      approvalsRequired,
+    });
+    
+    return expense;
+  }
+}

--- a/src/modules/condoExpenses/application/useCases/ListExpenses/ListExpensesController.ts
+++ b/src/modules/condoExpenses/application/useCases/ListExpenses/ListExpensesController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ListExpensesUseCase } from './ListExpensesUseCase';
+import { CondoExpenseResponseDTO } from '@/modules/condoExpenses/domain/dtos/CondoExpenseResponseDTO';
+
+@Tags('CondoExpenses')
+@Controller('condo-expenses')
+export class ListExpensesController {
+  @Get()
+  @Description('Lista todas as despesas do condomínio')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Expenses listed successfully',
+    dtoClass: [CondoExpenseResponseDTO],
+  })
+  @CommonResponses()
+  async handle(_req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(ListExpensesUseCase);
+    const expenses = await useCase.execute();
+    return res.json(expenses);
+  }
+}
+

--- a/src/modules/condoExpenses/application/useCases/ListExpenses/ListExpensesUseCase.ts
+++ b/src/modules/condoExpenses/application/useCases/ListExpenses/ListExpensesUseCase.ts
@@ -1,0 +1,18 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  ICondoExpensesRepository,
+  CONDO_EXPENSE_REPOSITORY,
+} from '@/modules/condoExpenses/domain/repositories/ICondoExpensesRepository';
+
+@injectable()
+export class ListExpensesUseCase {
+  constructor(
+    @inject(CONDO_EXPENSE_REPOSITORY)
+    private expensesRepository: ICondoExpensesRepository,
+  ) {}
+
+  async execute() {
+    return this.expensesRepository.findAll();
+  }
+}

--- a/src/modules/condoExpenses/domain/dtos/ApproveExpenseResponseDTO.ts
+++ b/src/modules/condoExpenses/domain/dtos/ApproveExpenseResponseDTO.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class ApproveExpenseResponseDTO {
+  @ApiProperty()
+  approvals!: number;
+}
+

--- a/src/modules/condoExpenses/domain/dtos/CondoExpenseResponseDTO.ts
+++ b/src/modules/condoExpenses/domain/dtos/CondoExpenseResponseDTO.ts
@@ -1,0 +1,34 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class CondoExpenseResponseDTO {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  description!: string;
+
+  @ApiProperty()
+  value!: number;
+
+  @ApiProperty()
+  date!: Date;
+
+  @ApiProperty({ required: false })
+  receiptUrl?: string;
+
+  @ApiProperty({ required: false })
+  pixKey?: string;
+
+  @ApiProperty()
+  approvalsRequired!: number;
+
+  @ApiProperty()
+  paid!: boolean;
+
+  @ApiProperty({ required: false })
+  paidByUserId?: number;
+
+  @ApiProperty({ required: false })
+  paidByApartmentId?: number;
+}
+

--- a/src/modules/condoExpenses/domain/dtos/CreateExpenseDTO.ts
+++ b/src/modules/condoExpenses/domain/dtos/CreateExpenseDTO.ts
@@ -1,0 +1,23 @@
+import { IsDateString, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateExpenseDTO {
+  @IsString()
+  description!: string;
+
+  @IsNumber()
+  value!: number;
+
+  @IsDateString()
+  date!: string;
+
+  @IsOptional()
+  @IsString()
+  receiptUrl?: string;
+
+  @IsOptional()
+  @IsString()
+  pixKey?: string;
+
+  @IsNumber()
+  approvalsRequired!: number;
+}

--- a/src/modules/condoExpenses/domain/entities/CondoExpense.ts
+++ b/src/modules/condoExpenses/domain/entities/CondoExpense.ts
@@ -1,0 +1,46 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+
+@Entity('condo_expenses')
+export class CondoExpense {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  description!: string;
+
+  @Column('decimal', { precision: 10, scale: 2 })
+  value!: number;
+
+  @Column('date')
+  date!: Date;
+
+  @Column({ nullable: true })
+  receiptUrl?: string;
+
+  @Column({ nullable: true })
+  pixKey?: string;
+
+  @Column({ type: 'int', default: 0 })
+  approvalsRequired!: number;
+
+  @Column({ default: false })
+  paid!: boolean;
+
+  @Column({ nullable: true })
+  paidByUserId?: number;
+
+  @Column({ nullable: true })
+  paidByApartmentId?: number;
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  @UpdateDateColumn()
+  updated_at!: Date;
+}

--- a/src/modules/condoExpenses/domain/entities/ExpenseApproval.ts
+++ b/src/modules/condoExpenses/domain/entities/ExpenseApproval.ts
@@ -1,0 +1,34 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  JoinColumn,
+} from 'typeorm';
+
+import { CondoExpense } from '@/modules/condoExpenses/domain/entities/CondoExpense';
+import { User } from '@/modules/users/domain/entities/User';
+
+@Entity('expense_approvals')
+export class ExpenseApproval {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @ManyToOne(() => CondoExpense)
+  @JoinColumn({ name: 'expenseId' })
+  expense!: CondoExpense;
+
+  @Column()
+  expenseId!: number;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'userId' })
+  user!: User;
+
+  @Column()
+  userId!: number;
+
+  @CreateDateColumn()
+  created_at!: Date;
+}

--- a/src/modules/condoExpenses/domain/repositories/ICondoExpensesRepository.ts
+++ b/src/modules/condoExpenses/domain/repositories/ICondoExpensesRepository.ts
@@ -1,0 +1,7 @@
+import { CondoExpense } from '@/modules/condoExpenses/domain/entities/CondoExpense';
+import { IGenericRepository } from '@/shared/generic/repositories/IGenericRepository';
+
+export const CONDO_EXPENSE_REPOSITORY = 'CONDO_EXPENSE_REPOSITORY';
+
+export interface ICondoExpensesRepository
+  extends IGenericRepository<CondoExpense> {}

--- a/src/modules/condoExpenses/domain/repositories/IExpenseApprovalsRepository.ts
+++ b/src/modules/condoExpenses/domain/repositories/IExpenseApprovalsRepository.ts
@@ -1,0 +1,10 @@
+import { ExpenseApproval } from '@/modules/condoExpenses/domain/entities/ExpenseApproval';
+import { IGenericRepository } from '@/shared/generic/repositories/IGenericRepository';
+
+export const EXPENSE_APPROVAL_REPOSITORY = 'EXPENSE_APPROVAL_REPOSITORY';
+
+export interface IExpenseApprovalsRepository
+  extends IGenericRepository<ExpenseApproval> {
+  countByExpense(expenseId: number): Promise<number>;
+  hasUserApproved(expenseId: number, userId: number): Promise<boolean>;
+}

--- a/src/modules/condoExpenses/infra/repositories/CondoExpensesRepository.ts
+++ b/src/modules/condoExpenses/infra/repositories/CondoExpensesRepository.ts
@@ -1,0 +1,16 @@
+import { inject, injectable } from 'tsyringe';
+import { DataSource } from 'typeorm';
+
+import { CondoExpense } from '@/modules/condoExpenses/domain/entities/CondoExpense';
+import { GenericRepository } from '@/shared/generic/repositories/GenericRepository';
+import { ICondoExpensesRepository } from '@/modules/condoExpenses/domain/repositories/ICondoExpensesRepository';
+
+@injectable()
+export class CondoExpensesRepository
+  extends GenericRepository<CondoExpense>
+  implements ICondoExpensesRepository
+{
+  constructor(@inject('DataSource') dataSource: DataSource) {
+    super(dataSource.getRepository(CondoExpense));
+  }
+}

--- a/src/modules/condoExpenses/infra/repositories/ExpenseApprovalsRepository.ts
+++ b/src/modules/condoExpenses/infra/repositories/ExpenseApprovalsRepository.ts
@@ -1,0 +1,25 @@
+import { inject, injectable } from 'tsyringe';
+import { DataSource } from 'typeorm';
+
+import { ExpenseApproval } from '@/modules/condoExpenses/domain/entities/ExpenseApproval';
+import { IExpenseApprovalsRepository } from '@/modules/condoExpenses/domain/repositories/IExpenseApprovalsRepository';
+import { GenericRepository } from '@/shared/generic/repositories/GenericRepository';
+
+@injectable()
+export class ExpenseApprovalsRepository
+  extends GenericRepository<ExpenseApproval>
+  implements IExpenseApprovalsRepository
+{
+  constructor(@inject('DataSource') dataSource: DataSource) {
+    super(dataSource.getRepository(ExpenseApproval));
+  }
+
+  async countByExpense(expenseId: number): Promise<number> {
+    return this.ormRepo.count({ where: { expenseId } });
+  }
+
+  async hasUserApproved(expenseId: number, userId: number): Promise<boolean> {
+    const found = await this.ormRepo.findOne({ where: { expenseId, userId } });
+    return !!found;
+  }
+}

--- a/src/modules/condoFees/application/useCases/AsaasWebhook/AsaasWebhookController.ts
+++ b/src/modules/condoFees/application/useCases/AsaasWebhook/AsaasWebhookController.ts
@@ -1,0 +1,29 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import { Controller, Post, Tags, ApiResponse } from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { UpdateFeeStatusUseCase } from './UpdateFeeStatusUseCase';
+
+@Tags('Asaas')
+@Controller('asaas')
+export class AsaasWebhookController {
+  @Post('webhook')
+  @Description('Recebe notificações de pagamento do Asaas')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Webhook recebido',
+  })
+  async handle(req: Request, res: Response): Promise<Response> {
+    const event = req.body?.event;
+    if (event === 'PAYMENT_RECEIVED') {
+      const external = req.body?.payment?.externalReference;
+      if (external) {
+        const useCase = container.resolve(UpdateFeeStatusUseCase);
+        await useCase.execute(external);
+      }
+    }
+    return res.status(200).send();
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/AsaasWebhook/UpdateFeeStatusUseCase.ts
+++ b/src/modules/condoFees/application/useCases/AsaasWebhook/UpdateFeeStatusUseCase.ts
@@ -1,0 +1,30 @@
+import { inject, injectable } from 'tsyringe';
+import { In } from 'typeorm';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+
+@injectable()
+export class UpdateFeeStatusUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+  ) {}
+
+  async execute(externalReference: string): Promise<void> {
+    const ids = externalReference.split(',').map(id => Number(id));
+    const fees = await this.feesRepository.findAll({
+      where: { id: In(ids) } as any,
+    });
+
+    for (const fee of fees) {
+      await this.feesRepository.update({
+        id: fee.id,
+        status: FeeStatusEnum.PAID,
+      });
+    }
+  }
+}

--- a/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesController.ts
+++ b/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesController.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { GenerateAnnualFeesUseCase } from './GenerateAnnualFeesUseCase';
+import { GenerateFeesDTO } from '@/modules/condoFees/domain/dtos/GenerateFeesDTO';
+import { MessageResponseDTO } from '@/shared/http/dtos/MessageResponseDTO';
+
+@Tags('CondoFees')
+@Controller('condo-fees')
+export class GenerateAnnualFeesController {
+  @Post('generate')
+  @Description('Gera as taxas condominiais do ano informado')
+  @ApiResponse({
+    statusCode: 201,
+    description: 'Taxas geradas com sucesso',
+    dtoClass: MessageResponseDTO,
+  })
+  @Body(GenerateFeesDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(GenerateAnnualFeesUseCase);
+    await useCase.execute(req.body);
+    return res.status(201).json({ message: 'Taxas geradas' });
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesUseCase.ts
+++ b/src/modules/condoFees/application/useCases/GenerateAnnualFees/GenerateAnnualFeesUseCase.ts
@@ -1,0 +1,39 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { GenerateFeesDTO } from '@/modules/condoFees/domain/dtos/GenerateFeesDTO';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+import {
+  IApartmentsRepository,
+  APARTMENT_REPOSITORY,
+} from '@/modules/apartments/domain/repositories/IApartmentsRepository';
+
+@injectable()
+export class GenerateAnnualFeesUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+    @inject(APARTMENT_REPOSITORY)
+    private apartmentsRepository: IApartmentsRepository,
+  ) {}
+
+  async execute({ year, amount }: GenerateFeesDTO): Promise<void> {
+    const apartments = await this.apartmentsRepository.findAll();
+    for (const apartment of apartments) {
+      for (let month = 1; month <= 12; month++) {
+        const dueDate = new Date(year, month - 1, 10);
+        await this.feesRepository.create({
+          month,
+          year,
+          amount,
+          status: FeeStatusEnum.PENDING,
+          dueDate,
+          apartmentId: apartment.id,
+        });
+      }
+    }
+  }
+}

--- a/src/modules/condoFees/application/useCases/GetAsaasBalance/GetAsaasBalanceController.ts
+++ b/src/modules/condoFees/application/useCases/GetAsaasBalance/GetAsaasBalanceController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { GetAsaasBalanceUseCase } from './GetAsaasBalanceUseCase';
+import { AsaasBalanceDTO } from '@/modules/condoFees/domain/dtos/AsaasBalanceDTO';
+
+@Tags('Asaas')
+@Controller('asaas')
+export class GetAsaasBalanceController {
+  @Get('balance')
+  @Description('Consulta o saldo da conta Asaas')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Saldo obtido com sucesso',
+    dtoClass: AsaasBalanceDTO,
+  })
+  @CommonResponses()
+  async handle(_req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(GetAsaasBalanceUseCase);
+    const result = await useCase.execute();
+    return res.json(result);
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/GetAsaasBalance/GetAsaasBalanceUseCase.ts
+++ b/src/modules/condoFees/application/useCases/GetAsaasBalance/GetAsaasBalanceUseCase.ts
@@ -1,0 +1,11 @@
+import { injectable } from 'tsyringe';
+
+import { AsaasClient } from '@/shared/providers/asaas/AsaasClient';
+
+@injectable()
+export class GetAsaasBalanceUseCase {
+  async execute() {
+    const client = new AsaasClient();
+    return client.getAccountBalance();
+  }
+}

--- a/src/modules/condoFees/application/useCases/GetAsaasTransactions/GetAsaasTransactionsController.ts
+++ b/src/modules/condoFees/application/useCases/GetAsaasTransactions/GetAsaasTransactionsController.ts
@@ -1,0 +1,32 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { GetAsaasTransactionsUseCase } from './GetAsaasTransactionsUseCase';
+import { AsaasTransactionDTO } from '@/modules/condoFees/domain/dtos/AsaasTransactionDTO';
+
+@Tags('Asaas')
+@Controller('asaas')
+export class GetAsaasTransactionsController {
+  @Get('transactions')
+  @Description('Lista o histórico de transações da conta Asaas')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Transações listadas com sucesso',
+    dtoClass: [AsaasTransactionDTO],
+  })
+  @CommonResponses()
+  async handle(_req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(GetAsaasTransactionsUseCase);
+    const result = await useCase.execute();
+    return res.json(result);
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/GetAsaasTransactions/GetAsaasTransactionsUseCase.ts
+++ b/src/modules/condoFees/application/useCases/GetAsaasTransactions/GetAsaasTransactionsUseCase.ts
@@ -1,0 +1,11 @@
+import { injectable } from 'tsyringe';
+
+import { AsaasClient } from '@/shared/providers/asaas/AsaasClient';
+
+@injectable()
+export class GetAsaasTransactionsUseCase {
+  async execute() {
+    const client = new AsaasClient();
+    return client.getTransactions();
+  }
+}

--- a/src/modules/condoFees/application/useCases/GetMyPendingFees/GetMyPendingFeesController.ts
+++ b/src/modules/condoFees/application/useCases/GetMyPendingFees/GetMyPendingFeesController.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  UseMiddleware,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ensureAuthenticated } from '@/shared/http/middlewares/ensureAuthenticated';
+import { GetMyPendingFeesUseCase } from './GetMyPendingFeesUseCase';
+import { PendingFeesSummaryDTO } from '@/modules/condoFees/domain/dtos/PendingFeesSummaryDTO';
+
+@Tags('CondoFees')
+@Controller('condo-fees')
+export class GetMyPendingFeesController {
+  @Get('me/pending-summary')
+  @Description('Resumo de taxas pendentes do meu apartamento')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Resumo obtido com sucesso',
+    dtoClass: PendingFeesSummaryDTO,
+  })
+  @UseMiddleware(ensureAuthenticated)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(GetMyPendingFeesUseCase);
+    const result = await useCase.execute(Number(req.user!.id));
+    return res.json(result);
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/GetMyPendingFees/GetMyPendingFeesUseCase.ts
+++ b/src/modules/condoFees/application/useCases/GetMyPendingFees/GetMyPendingFeesUseCase.ts
@@ -1,0 +1,39 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import {
+  IUsersRepository,
+  USER_REPOSITORY,
+} from '@/modules/users/domain/repositories/IUsersRepository';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+import { AppError } from '@/shared/core/errors/AppError';
+
+@injectable()
+export class GetMyPendingFeesUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+    @inject(USER_REPOSITORY)
+    private usersRepository: IUsersRepository,
+  ) {}
+
+  async execute(userId: number) {
+    const user = await this.usersRepository.findById(userId);
+    if (!user) throw new AppError('User not found', 404, 'business');
+
+    const fees = await this.feesRepository.findAll({
+      where: {
+        apartmentId: user.apartmentId,
+        status: FeeStatusEnum.PENDING,
+      } as any,
+    });
+
+    const count = fees.length;
+    const total = fees.reduce((acc, fee) => acc + Number(fee.amount), 0);
+
+    return { hasPending: count > 0, count, total };
+  }
+}

--- a/src/modules/condoFees/application/useCases/ListMyFees/ListMyFeesController.ts
+++ b/src/modules/condoFees/application/useCases/ListMyFees/ListMyFeesController.ts
@@ -1,0 +1,46 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  UseMiddleware,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ensureAuthenticated } from '@/shared/http/middlewares/ensureAuthenticated';
+import { ListMyFeesUseCase } from './ListMyFeesUseCase';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+import { CondoFeeResponseDTO } from '@/modules/condoFees/domain/dtos/CondoFeeResponseDTO';
+
+@Tags('CondoFees')
+@Controller('condo-fees')
+export class ListMyFeesController {
+  @Get('me')
+  @Description('Lista taxas do meu apartamento')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Taxas listadas com sucesso',
+    dtoClass: [CondoFeeResponseDTO],
+  })
+  @UseMiddleware(ensureAuthenticated)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(ListMyFeesUseCase);
+
+    const { status, year } = req.query;
+    const parsedStatus = typeof status === 'string' ? (status.toUpperCase() as FeeStatusEnum) : undefined;
+    const parsedYear = year ? Number(year) : undefined;
+
+    const fees = await useCase.execute({
+      userId: Number(req.user!.id),
+      status: parsedStatus,
+      year: parsedYear,
+    });
+
+    return res.json(fees);
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/ListMyFees/ListMyFeesUseCase.ts
+++ b/src/modules/condoFees/application/useCases/ListMyFees/ListMyFeesUseCase.ts
@@ -1,0 +1,40 @@
+import { inject, injectable } from 'tsyringe';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import {
+  IUsersRepository,
+  USER_REPOSITORY,
+} from '@/modules/users/domain/repositories/IUsersRepository';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+import { AppError } from '@/shared/core/errors/AppError';
+
+interface IRequest {
+  userId: number;
+  status?: FeeStatusEnum;
+  year?: number;
+}
+
+@injectable()
+export class ListMyFeesUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+    @inject(USER_REPOSITORY)
+    private usersRepository: IUsersRepository,
+  ) {}
+
+  async execute({ userId, status, year }: IRequest) {
+    const user = await this.usersRepository.findById(userId);
+    if (!user) throw new AppError('User not found', 404, 'business');
+
+    const where: any = { apartmentId: user.apartmentId };
+    if (status) where.status = status;
+    if (year) where.year = year;
+
+    const fees = await this.feesRepository.findAll({ where, order: { year: 'ASC', month: 'ASC' } as any });
+    return fees;
+  }
+}

--- a/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesController.ts
+++ b/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesController.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { PayFeesDTO } from '@/modules/condoFees/domain/dtos/PayFeesDTO';
+import { PayCondoFeesUseCase } from './PayCondoFeesUseCase';
+import { AsaasPaymentResponseDTO } from '@/modules/condoFees/domain/dtos/AsaasPaymentResponseDTO';
+
+@Tags('CondoFees')
+@Controller('condo-fees')
+export class PayCondoFeesController {
+  @Post('pay')
+  @Description('Cria cobrança via Asaas para taxas selecionadas')
+  @ApiResponse({
+    statusCode: 201,
+    description: 'Pagamento criado com sucesso',
+    dtoClass: AsaasPaymentResponseDTO,
+  })
+  @Body(PayFeesDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(PayCondoFeesUseCase);
+    const result = await useCase.execute(req.body);
+    return res.status(201).json(result);
+  }
+}
+

--- a/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesUseCase.ts
+++ b/src/modules/condoFees/application/useCases/PayCondoFees/PayCondoFeesUseCase.ts
@@ -1,0 +1,45 @@
+import { inject, injectable } from 'tsyringe';
+import { In } from 'typeorm';
+
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { PayFeesDTO } from '@/modules/condoFees/domain/dtos/PayFeesDTO';
+import { AsaasClient } from '@/shared/providers/asaas/AsaasClient';
+
+@injectable()
+export class PayCondoFeesUseCase {
+  constructor(
+    @inject(CONDO_FEE_REPOSITORY)
+    private feesRepository: ICondoFeesRepository,
+  ) {}
+
+  async execute({ feeIds }: PayFeesDTO) {
+    const fees = await this.feesRepository.findAll({
+      where: { id: In(feeIds) } as any,
+    });
+
+    const total = fees.reduce((acc, fee) => acc + Number(fee.amount), 0);
+
+    const client = new AsaasClient();
+
+    const payment = await client.createPayment({
+      customer: process.env.ASAAS_CUSTOMER_ID || '',
+      billingType: 'PIX',
+      value: total,
+      description: 'Condo fees',
+      externalReference: feeIds.join(','),
+    });
+
+    for (const fee of fees) {
+      await this.feesRepository.update({
+        id: fee.id,
+        asaasPaymentId: payment.id,
+        externalReference: feeIds.join(','),
+      });
+    }
+
+    return payment;
+  }
+}

--- a/src/modules/condoFees/domain/dtos/AsaasBalanceDTO.ts
+++ b/src/modules/condoFees/domain/dtos/AsaasBalanceDTO.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class AsaasBalanceDTO {
+  @ApiProperty()
+  balance!: number;
+}
+

--- a/src/modules/condoFees/domain/dtos/AsaasPaymentResponseDTO.ts
+++ b/src/modules/condoFees/domain/dtos/AsaasPaymentResponseDTO.ts
@@ -1,0 +1,24 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+class PixQrCodeDTO {
+  @ApiProperty()
+  encodedImage!: string;
+
+  @ApiProperty()
+  payload!: string;
+}
+
+export class AsaasPaymentResponseDTO {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  status!: string;
+
+  @ApiProperty()
+  value!: number;
+
+  @ApiProperty({ required: false, type: PixQrCodeDTO })
+  pixQrCode?: PixQrCodeDTO;
+}
+

--- a/src/modules/condoFees/domain/dtos/AsaasTransactionDTO.ts
+++ b/src/modules/condoFees/domain/dtos/AsaasTransactionDTO.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class AsaasTransactionDTO {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  value!: number;
+
+  @ApiProperty({ required: false })
+  description?: string;
+}
+

--- a/src/modules/condoFees/domain/dtos/CondoFeeResponseDTO.ts
+++ b/src/modules/condoFees/domain/dtos/CondoFeeResponseDTO.ts
@@ -1,0 +1,32 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+
+export class CondoFeeResponseDTO {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  month!: number;
+
+  @ApiProperty()
+  year!: number;
+
+  @ApiProperty()
+  amount!: number;
+
+  @ApiProperty({ enum: FeeStatusEnum })
+  status!: FeeStatusEnum;
+
+  @ApiProperty({ required: false })
+  asaasPaymentId?: string;
+
+  @ApiProperty({ required: false })
+  externalReference?: string;
+
+  @ApiProperty()
+  dueDate!: Date;
+
+  @ApiProperty()
+  apartmentId!: number;
+}
+

--- a/src/modules/condoFees/domain/dtos/GenerateFeesDTO.ts
+++ b/src/modules/condoFees/domain/dtos/GenerateFeesDTO.ts
@@ -1,0 +1,9 @@
+import { IsNumber } from 'class-validator';
+
+export class GenerateFeesDTO {
+  @IsNumber()
+  year!: number;
+
+  @IsNumber()
+  amount!: number;
+}

--- a/src/modules/condoFees/domain/dtos/PayFeesDTO.ts
+++ b/src/modules/condoFees/domain/dtos/PayFeesDTO.ts
@@ -1,0 +1,8 @@
+import { ArrayNotEmpty, IsArray, IsNumber } from 'class-validator';
+
+export class PayFeesDTO {
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsNumber({}, { each: true })
+  feeIds!: number[];
+}

--- a/src/modules/condoFees/domain/dtos/PendingFeesSummaryDTO.ts
+++ b/src/modules/condoFees/domain/dtos/PendingFeesSummaryDTO.ts
@@ -1,0 +1,13 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class PendingFeesSummaryDTO {
+  @ApiProperty()
+  hasPending!: boolean;
+
+  @ApiProperty()
+  count!: number;
+
+  @ApiProperty()
+  total!: number;
+}
+

--- a/src/modules/condoFees/domain/entities/CondoFee.ts
+++ b/src/modules/condoFees/domain/entities/CondoFee.ts
@@ -1,0 +1,52 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  JoinColumn,
+} from 'typeorm';
+
+import { FeeStatusEnum } from '@/modules/condoFees/domain/enums/fee-status.enum';
+import { Apartment } from '@/modules/apartments/domain/entities/Apartment';
+
+@Entity('condo_fees')
+export class CondoFee {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  month!: number;
+
+  @Column()
+  year!: number;
+
+  @Column('decimal')
+  amount!: number;
+
+  @Column({ type: 'varchar', default: FeeStatusEnum.PENDING })
+  status!: FeeStatusEnum;
+
+  @Column({ nullable: true })
+  asaasPaymentId?: string;
+
+  @Column({ nullable: true })
+  externalReference?: string;
+
+  @Column({ type: 'date' })
+  dueDate!: Date;
+
+  @ManyToOne(() => Apartment, (apartment) => apartment.id)
+  @JoinColumn({ name: 'apartmentId' })
+  apartment!: Apartment;
+
+  @Column()
+  apartmentId!: number;
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  @UpdateDateColumn()
+  updated_at!: Date;
+}

--- a/src/modules/condoFees/domain/enums/fee-status.enum.ts
+++ b/src/modules/condoFees/domain/enums/fee-status.enum.ts
@@ -1,0 +1,4 @@
+export enum FeeStatusEnum {
+  PENDING = 'PENDING',
+  PAID = 'PAID',
+}

--- a/src/modules/condoFees/domain/repositories/ICondoFeesRepository.ts
+++ b/src/modules/condoFees/domain/repositories/ICondoFeesRepository.ts
@@ -1,0 +1,6 @@
+import { CondoFee } from '@/modules/condoFees/domain/entities/CondoFee';
+import { IGenericRepository } from '@/shared/generic/repositories/IGenericRepository';
+
+export const CONDO_FEE_REPOSITORY = 'CONDO_FEE_REPOSITORY';
+
+export interface ICondoFeesRepository extends IGenericRepository<CondoFee> {}

--- a/src/modules/condoFees/infra/repositories/CondoFeesRepository.ts
+++ b/src/modules/condoFees/infra/repositories/CondoFeesRepository.ts
@@ -1,0 +1,19 @@
+import { inject, injectable } from 'tsyringe';
+import { DataSource } from 'typeorm';
+
+import { CondoFee } from '@/modules/condoFees/domain/entities/CondoFee';
+import { GenericRepository } from '@/shared/generic/repositories/GenericRepository';
+import { ICondoFeesRepository } from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+
+@injectable()
+export class CondoFeesRepository
+  extends GenericRepository<CondoFee>
+  implements ICondoFeesRepository
+{
+  constructor(
+    @inject('DataSource')
+    dataSource: DataSource,
+  ) {
+    super(dataSource.getRepository(CondoFee));
+  }
+}

--- a/src/modules/health/application/useCases/checkHealth/CheckHealthController.ts
+++ b/src/modules/health/application/useCases/checkHealth/CheckHealthController.ts
@@ -1,16 +1,26 @@
 import { Request, Response } from 'express';
 import { container } from 'tsyringe';
 
-import { Controller, Get, Tags } from '@/shared/http/docs/decorators';
+import { Controller, Get, Tags, ApiResponse, CommonResponses } from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
 import { CheckHealthUseCase } from './CheckHealthUseCase';
+import { HealthCheckResponseDTO } from '@/modules/health/domain/dtos/HealthCheckResponseDTO';
 
 @Tags('Health')
 @Controller('/')
 export class CheckHealthController {
   @Get('health')
+  @Description('Service health check')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Serviço saudável',
+    dtoClass: HealthCheckResponseDTO,
+  })
+  @CommonResponses()
   async handle(req: Request, res: Response): Promise<Response> {
     const useCase = container.resolve(CheckHealthUseCase);
     const result = await useCase.execute();
     return res.json(result);
   }
 }
+

--- a/src/modules/health/domain/dtos/HealthCheckResponseDTO.ts
+++ b/src/modules/health/domain/dtos/HealthCheckResponseDTO.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class HealthCheckResponseDTO {
+  @ApiProperty()
+  status!: string;
+}
+

--- a/src/modules/requests/application/useCases/CreateRequests/CreateRequestsController.ts
+++ b/src/modules/requests/application/useCases/CreateRequests/CreateRequestsController.ts
@@ -9,9 +9,9 @@ import {
   Post,
   Tags,
 } from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
 import { CreateRequestsUseCase } from './CreateRequestsUseCase';
 import { CreateRequestDTO } from '@/modules/requests/domain/dtos/CreateRequestDTO';
-import { Description } from '@/shared/http/docs/decorators/Description';
 import { RequestDTO } from '@/modules/requests/domain/dtos/RequestResponseDTO';
 
 @Tags('Requests')
@@ -32,3 +32,4 @@ export class CreateRequestsController {
     return res.status(201).json(result);
   }
 }
+

--- a/src/modules/requests/application/useCases/UpdateRequestStatus/UpdateRequestStatusController.ts
+++ b/src/modules/requests/application/useCases/UpdateRequestStatus/UpdateRequestStatusController.ts
@@ -10,9 +10,9 @@ import {
   Post,
   Tags,
 } from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
 import { UpdateRequestStatusUseCase } from './UpdateRequestStatusUseCase';
 import { CreateRequestDTO } from '@/modules/requests/domain/dtos/CreateRequestDTO';
-import { Description } from '@/shared/http/docs/decorators/Description';
 import { RequestDTO } from '@/modules/requests/domain/dtos/RequestResponseDTO';
 import { UpdateStatusRequestDTO } from '@/modules/requests/domain/dtos/UpdateStatusRequestDTO';
 
@@ -30,7 +30,8 @@ export class UpdateRequestStatusController {
   @Body(UpdateStatusRequestDTO)
   async handle(req: Request, res: Response): Promise<Response> {
     const useCase = container.resolve(UpdateRequestStatusUseCase);
-    await useCase.execute(req.body);
-    return res.status(202).end();
+    await useCase.execute(req.body as CreateRequestDTO);
+    return res.status(202).json();
   }
 }
+

--- a/src/modules/requests/application/useCases/listRequests/ListRequestsController.ts
+++ b/src/modules/requests/application/useCases/listRequests/ListRequestsController.ts
@@ -2,8 +2,8 @@ import { Request, Response } from 'express';
 import { container } from 'tsyringe';
 
 import { ApiResponse, CommonResponses, Controller, Get, Tags } from '@/shared/http/docs/decorators';
-import { ListRequestsUseCase } from './ListRequestsUseCase';
 import { Description } from '@/shared/http/docs/decorators/Description';
+import { ListRequestsUseCase } from './ListRequestsUseCase';
 import { RequestDTO } from '@/modules/requests/domain/dtos/RequestResponseDTO';
 
 @Tags('Requests')
@@ -23,3 +23,4 @@ export class ListRequestsController {
     return res.json(result);
   }
 }
+

--- a/src/modules/users/application/useCases/CreateUser/CreateUserController.ts
+++ b/src/modules/users/application/useCases/CreateUser/CreateUserController.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  UseMiddleware,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ensureAuthenticated } from '@/shared/http/middlewares/ensureAuthenticated';
+import { ensureAdmin } from '@/shared/http/middlewares/ensureAdmin';
+import { CreateUserDTO } from '@/modules/users/domain/dtos/CreateUserDTO';
+import { UserResponseDTO } from '@/modules/users/domain/dtos/UserResponseDTO';
+import { CreateUserUseCase } from './CreateUserUseCase';
+
+@Tags('Users')
+@Controller('users')
+export class CreateUserController {
+  @Post()
+  @Description('Create a new user')
+  @ApiResponse({
+    statusCode: 201,
+    description: 'User created successfully',
+    dtoClass: UserResponseDTO,
+  })
+  @Body(CreateUserDTO)
+  @UseMiddleware(ensureAuthenticated, ensureAdmin)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(CreateUserUseCase);
+    const user = await useCase.execute(req.body);
+    const { password: _, ...userWithoutPassword } = user as any;
+    return res.status(201).json(userWithoutPassword);
+  }
+}
+

--- a/src/modules/users/application/useCases/CreateUser/CreateUserUseCase.ts
+++ b/src/modules/users/application/useCases/CreateUser/CreateUserUseCase.ts
@@ -1,0 +1,39 @@
+import { inject, injectable } from 'tsyringe';
+import { hash } from 'bcryptjs';
+
+import { IUsersRepository, USER_REPOSITORY } from '@/modules/users/domain/repositories/IUsersRepository';
+
+@injectable()
+export class CreateUserUseCase {
+  constructor(
+    @inject(USER_REPOSITORY)
+    private usersRepository: IUsersRepository,
+  ) {}
+
+  async execute({
+    name,
+    email,
+    phone,
+    apartmentId,
+    password,
+    isAdmin = false,
+  }: {
+    name: string;
+    email: string;
+    phone: string;
+    apartmentId: number;
+    password: string;
+    isAdmin?: boolean;
+  }) {
+    const hashedPassword = await hash(password, 8);
+    const user = await this.usersRepository.create({
+      name,
+      email,
+      phone,
+      apartmentId,
+      password: hashedPassword,
+      isAdmin,
+    });
+    return user;
+  }
+}

--- a/src/modules/users/application/useCases/ListUsers/ListUsersController.ts
+++ b/src/modules/users/application/useCases/ListUsers/ListUsersController.ts
@@ -1,0 +1,40 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Controller,
+  Get,
+  Tags,
+  CommonResponses,
+  UseMiddleware,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { ensureAuthenticated } from '@/shared/http/middlewares/ensureAuthenticated';
+import { ensureAdmin } from '@/shared/http/middlewares/ensureAdmin';
+import { ListUsersUseCase } from './ListUsersUseCase';
+import { UserResponseDTO } from '@/modules/users/domain/dtos/UserResponseDTO';
+
+@Tags('Users')
+@Controller('users')
+export class ListUsersController {
+  @Get()
+  @Description('List all users')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Users listed successfully',
+    dtoClass: [UserResponseDTO],
+  })
+  @UseMiddleware(ensureAuthenticated, ensureAdmin)
+  @CommonResponses()
+  async handle(_req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(ListUsersUseCase);
+    const users = await useCase.execute();
+    const sanitized = users.map((u: any) => {
+      const { password, ...rest } = u;
+      return rest;
+      });
+    return res.json(sanitized);
+  }
+}
+

--- a/src/modules/users/application/useCases/ListUsers/ListUsersUseCase.ts
+++ b/src/modules/users/application/useCases/ListUsers/ListUsersUseCase.ts
@@ -1,0 +1,15 @@
+import { inject, injectable } from 'tsyringe';
+
+import { IUsersRepository, USER_REPOSITORY } from '@/modules/users/domain/repositories/IUsersRepository';
+
+@injectable()
+export class ListUsersUseCase {
+  constructor(
+    @inject(USER_REPOSITORY)
+    private usersRepository: IUsersRepository,
+  ) {}
+
+  async execute() {
+    return this.usersRepository.findAll({ relations: ['apartment'] });
+  }
+}

--- a/src/modules/users/application/useCases/Login/LoginController.ts
+++ b/src/modules/users/application/useCases/Login/LoginController.ts
@@ -1,0 +1,35 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+
+import {
+  Body,
+  Controller,
+  Post,
+  Tags,
+  CommonResponses,
+  ApiResponse,
+} from '@/shared/http/docs/decorators';
+import { Description } from '@/shared/http/docs/decorators/Description';
+import { LoginDTO } from '@/modules/users/domain/dtos/LoginDTO';
+import { LoginUseCase } from './LoginUseCase';
+import { LoginResponseDTO } from '@/modules/users/domain/dtos/LoginResponseDTO';
+
+@Tags('Auth')
+@Controller('sessions')
+export class LoginController {
+  @Post()
+  @Description('Authenticate user')
+  @ApiResponse({
+    statusCode: 200,
+    description: 'Authentication successful',
+    dtoClass: LoginResponseDTO,
+  })
+  @Body(LoginDTO)
+  @CommonResponses()
+  async handle(req: Request, res: Response): Promise<Response> {
+    const useCase = container.resolve(LoginUseCase);
+    const token = await useCase.execute(req.body);
+    return res.json(token);
+  }
+}
+

--- a/src/modules/users/application/useCases/Login/LoginUseCase.ts
+++ b/src/modules/users/application/useCases/Login/LoginUseCase.ts
@@ -1,0 +1,38 @@
+import { inject, injectable } from 'tsyringe';
+import { compare } from 'bcryptjs';
+import { sign } from 'jsonwebtoken';
+
+import { IUsersRepository, USER_REPOSITORY } from '@/modules/users/domain/repositories/IUsersRepository';
+import { AppError } from '@/shared/core/errors/AppError';
+
+interface IRequest {
+  email: string;
+  password: string;
+}
+
+@injectable()
+export class LoginUseCase {
+  constructor(
+    @inject(USER_REPOSITORY)
+    private usersRepository: IUsersRepository,
+  ) {}
+
+  async execute({ email, password }: IRequest) {
+    const user = await this.usersRepository.findOne({ where: { email } });
+    if (!user) throw new AppError('Invalid credentials', 401, 'auth');
+
+    const passwordMatches = await compare(password, user.password);
+    if (!passwordMatches) throw new AppError('Invalid credentials', 401, 'auth');
+
+    const token = sign(
+      { email: user.email, isAdmin: user.isAdmin },
+      process.env.JWT_SECRET!,
+      {
+        subject: String(user.id),
+        expiresIn: '1d',
+      },
+    );
+
+    return { token };
+  }
+}

--- a/src/modules/users/domain/dtos/CreateUserDTO.ts
+++ b/src/modules/users/domain/dtos/CreateUserDTO.ts
@@ -1,0 +1,22 @@
+import { IsBoolean, IsEmail, IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateUserDTO {
+  @IsString()
+  name!: string;
+
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  password!: string;
+
+  @IsString()
+  phone!: string;
+
+  @IsOptional()
+  @IsBoolean()
+  isAdmin?: boolean;
+
+  @IsNumber()
+  apartmentId!: number;
+}

--- a/src/modules/users/domain/dtos/LoginDTO.ts
+++ b/src/modules/users/domain/dtos/LoginDTO.ts
@@ -1,0 +1,9 @@
+import { IsEmail, IsString } from 'class-validator';
+
+export class LoginDTO {
+  @IsEmail()
+  email!: string;
+
+  @IsString()
+  password!: string;
+}

--- a/src/modules/users/domain/dtos/LoginResponseDTO.ts
+++ b/src/modules/users/domain/dtos/LoginResponseDTO.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class LoginResponseDTO {
+  @ApiProperty()
+  token!: string;
+}
+

--- a/src/modules/users/domain/dtos/UserResponseDTO.ts
+++ b/src/modules/users/domain/dtos/UserResponseDTO.ts
@@ -1,0 +1,22 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class UserResponseDTO {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  email!: string;
+
+  @ApiProperty()
+  phone!: string;
+
+  @ApiProperty()
+  isAdmin!: boolean;
+
+  @ApiProperty()
+  apartmentId!: number;
+}
+

--- a/src/modules/users/domain/entities/User.ts
+++ b/src/modules/users/domain/entities/User.ts
@@ -1,0 +1,45 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+  JoinColumn,
+} from 'typeorm';
+
+import { Apartment } from '@/modules/apartments/domain/entities/Apartment';
+
+@Entity('users')
+export class User {
+  @PrimaryGeneratedColumn()
+  id!: number;
+
+  @Column()
+  name!: string;
+
+  @Column()
+  email!: string;
+
+  @Column()
+  password!: string;
+
+  @Column()
+  phone!: string;
+
+  @Column({ default: false })
+  isAdmin!: boolean;
+
+  @ManyToOne(() => Apartment, (apartment) => apartment.users)
+  @JoinColumn({ name: 'apartmentId' })
+  apartment!: Apartment;
+
+  @Column()
+  apartmentId!: number;
+
+  @CreateDateColumn()
+  created_at!: Date;
+
+  @UpdateDateColumn()
+  updated_at!: Date;
+}

--- a/src/modules/users/domain/repositories/IUsersRepository.ts
+++ b/src/modules/users/domain/repositories/IUsersRepository.ts
@@ -1,0 +1,6 @@
+import { User } from '@/modules/users/domain/entities/User';
+import { IGenericRepository } from '@/shared/generic/repositories/IGenericRepository';
+
+export const USER_REPOSITORY = 'USER_REPOSITORY';
+
+export interface IUsersRepository extends IGenericRepository<User> {}

--- a/src/modules/users/infra/repositories/UsersRepository.ts
+++ b/src/modules/users/infra/repositories/UsersRepository.ts
@@ -1,0 +1,16 @@
+import { inject, injectable } from 'tsyringe';
+import { DataSource } from 'typeorm';
+
+import { User } from '@/modules/users/domain/entities/User';
+import { IUsersRepository } from '@/modules/users/domain/repositories/IUsersRepository';
+import { GenericRepository } from '@/shared/generic/repositories/GenericRepository';
+
+@injectable()
+export class UsersRepository
+  extends GenericRepository<User>
+  implements IUsersRepository
+{
+  constructor(@inject('DataSource') dataSource: DataSource) {
+    super(dataSource.getRepository(User));
+  }
+}

--- a/src/shared/container/respositories.ts
+++ b/src/shared/container/respositories.ts
@@ -4,7 +4,55 @@ import {
   REQUEST_REPOSITORY,
 } from '@/modules/requests/domain/repositories/IRequestsRepository';
 import { RequestsRepository } from '@/modules/requests/infra/repositories/RequestsRepository';
+import {
+  ICondoFeesRepository,
+  CONDO_FEE_REPOSITORY,
+} from '@/modules/condoFees/domain/repositories/ICondoFeesRepository';
+import { CondoFeesRepository } from '@/modules/condoFees/infra/repositories/CondoFeesRepository';
+import {
+  ICondoExpensesRepository,
+  CONDO_EXPENSE_REPOSITORY,
+} from '@/modules/condoExpenses/domain/repositories/ICondoExpensesRepository';
+import { CondoExpensesRepository } from '@/modules/condoExpenses/infra/repositories/CondoExpensesRepository';
+import {
+  IApartmentsRepository,
+  APARTMENT_REPOSITORY,
+} from '@/modules/apartments/domain/repositories/IApartmentsRepository';
+import { ApartmentsRepository } from '@/modules/apartments/infra/repositories/ApartmentsRepository';
+import {
+  IUsersRepository,
+  USER_REPOSITORY,
+} from '@/modules/users/domain/repositories/IUsersRepository';
+import { UsersRepository } from '@/modules/users/infra/repositories/UsersRepository';
+import {
+  IExpenseApprovalsRepository,
+  EXPENSE_APPROVAL_REPOSITORY,
+} from '@/modules/condoExpenses/domain/repositories/IExpenseApprovalsRepository';
+import { ExpenseApprovalsRepository } from '@/modules/condoExpenses/infra/repositories/ExpenseApprovalsRepository';
 
 export async function registerRepositoriesProviders(): Promise<void> {
-  container.registerSingleton<IRequestsRepository>(REQUEST_REPOSITORY, RequestsRepository);
+  container.registerSingleton<IRequestsRepository>(
+    REQUEST_REPOSITORY,
+    RequestsRepository,
+  );
+  container.registerSingleton<ICondoFeesRepository>(
+    CONDO_FEE_REPOSITORY,
+    CondoFeesRepository,
+  );
+  container.registerSingleton<ICondoExpensesRepository>(
+    CONDO_EXPENSE_REPOSITORY,
+    CondoExpensesRepository,
+  );
+  container.registerSingleton<IApartmentsRepository>(
+    APARTMENT_REPOSITORY,
+    ApartmentsRepository,
+  );
+  container.registerSingleton<IUsersRepository>(
+    USER_REPOSITORY,
+    UsersRepository,
+  );
+  container.registerSingleton<IExpenseApprovalsRepository>(
+    EXPENSE_APPROVAL_REPOSITORY,
+    ExpenseApprovalsRepository,
+  );
 }

--- a/src/shared/http/dtos/MessageResponseDTO.ts
+++ b/src/shared/http/dtos/MessageResponseDTO.ts
@@ -1,0 +1,7 @@
+import { ApiProperty } from '@/shared/http/docs/decorators/ApiProperty';
+
+export class MessageResponseDTO {
+  @ApiProperty()
+  message!: string;
+}
+

--- a/src/shared/http/middlewares/ensureAdmin.ts
+++ b/src/shared/http/middlewares/ensureAdmin.ts
@@ -1,0 +1,8 @@
+import { NextFunction, Request, Response } from 'express';
+
+export function ensureAdmin(req: Request, res: Response, next: NextFunction) {
+  if (!req.user?.isAdmin) {
+    return res.status(403).json({ message: 'Admins only' });
+  }
+  return next();
+}

--- a/src/shared/http/middlewares/ensureAuthenticated.ts
+++ b/src/shared/http/middlewares/ensureAuthenticated.ts
@@ -13,6 +13,7 @@ export function ensureAuthenticated(req: Request, res: Response, next: NextFunct
     req.user = {
       id: (decoded as any).sub,
       email: (decoded as any).email,
+      isAdmin: (decoded as any).isAdmin,
     };
     return next();
   } catch {

--- a/src/shared/providers/asaas/AsaasClient.ts
+++ b/src/shared/providers/asaas/AsaasClient.ts
@@ -1,0 +1,96 @@
+import 'dotenv/config';
+
+interface AsaasPaymentRequest {
+  customer: string;
+  billingType: 'PIX';
+  value: number;
+  description?: string;
+  externalReference?: string;
+}
+
+interface AsaasPaymentResponse {
+  id: string;
+  status: string;
+  value: number;
+  pixQrCode?: {
+    encodedImage: string;
+    payload: string;
+  };
+}
+
+interface AsaasPixPayRequest {
+  pixKey: string;
+  value: number;
+  description?: string;
+}
+
+export class AsaasClient {
+  private baseUrl = process.env.ASAAS_API_URL || 'https://api.asaas.com/v3';
+  private apiKey = process.env.ASAAS_API_KEY || '';
+
+  async createPayment(
+    data: AsaasPaymentRequest,
+  ): Promise<AsaasPaymentResponse> {
+    const response = await fetch(`${this.baseUrl}/payments`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        access_token: this.apiKey,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to create payment on Asaas');
+    }
+
+    return response.json();
+  }
+
+  async getAccountBalance(): Promise<any> {
+    const response = await fetch(`${this.baseUrl}/finance/balance`, {
+      method: 'GET',
+      headers: {
+        access_token: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch balance from Asaas');
+    }
+
+    return response.json();
+  }
+
+  async getTransactions(): Promise<any> {
+    const response = await fetch(`${this.baseUrl}/financialTransactions`, {
+      method: 'GET',
+      headers: {
+        access_token: this.apiKey,
+      },
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch transactions from Asaas');
+    }
+
+    return response.json();
+  }
+
+  async payPix(data: AsaasPixPayRequest): Promise<any> {
+    const response = await fetch(`${this.baseUrl}/pix/pay`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        access_token: this.apiKey,
+      },
+      body: JSON.stringify(data),
+    });
+
+    if (!response.ok) {
+      throw new Error('Failed to pay PIX on Asaas');
+    }
+
+    return response.json();
+  }
+}

--- a/src/shared/providers/typeorm/config/ormConfig.ts
+++ b/src/shared/providers/typeorm/config/ormConfig.ts
@@ -4,19 +4,13 @@ import path from 'path';
 import { DataSource } from 'typeorm';
 
 export default new DataSource({
-  type: 'mssql',
+  type: 'mysql',
   host: process.env.DB_HOST,
   port: Number(process.env.DB_PORT),
   username: process.env.DB_USER,
   password: process.env.DB_PASS,
   database: process.env.DB_NAME,
   synchronize: false,
-  extra: {
-    options: {
-      encrypt: true,
-      trustServerCertificate: true,
-    },
-  },
   logging: true,
   entities: [
     process.env.NODE_ENV === 'development'

--- a/src/shared/providers/typeorm/migrations/1744925335300-create-table-requests.ts
+++ b/src/shared/providers/typeorm/migrations/1744925335300-create-table-requests.ts
@@ -25,12 +25,12 @@ export class CreateTableRequests1744925335300 implements MigrationInterface {
           {
             name: 'created_at',
             type: 'datetime',
-            default: 'GETDATE()',
+            default: 'CURRENT_TIMESTAMP',
           },
           {
             name: 'updated_at',
             type: 'datetime',
-            default: 'GETDATE()',
+            default: 'CURRENT_TIMESTAMP',
           },
         ],
       }),

--- a/src/shared/providers/typeorm/migrations/1744931200000-create-table-condo-fees.ts
+++ b/src/shared/providers/typeorm/migrations/1744931200000-create-table-condo-fees.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTableCondoFees1744931200000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'condo_fees',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'month', type: 'int' },
+          { name: 'year', type: 'int' },
+          { name: 'amount', type: 'decimal', precision: 10, scale: 2 },
+          { name: 'status', type: 'varchar' },
+          { name: 'asaasPaymentId', type: 'varchar', isNullable: true },
+          { name: 'externalReference', type: 'varchar', isNullable: true },
+          { name: 'dueDate', type: 'date' },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+          { name: 'updated_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('condo_fees');
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931300000-create-table-condo-expenses.ts
+++ b/src/shared/providers/typeorm/migrations/1744931300000-create-table-condo-expenses.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTableCondoExpenses1744931300000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'condo_expenses',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          { name: 'description', type: 'varchar' },
+          {
+            name: 'value',
+            type: 'decimal',
+            precision: 10,
+            scale: 2,
+          },
+          { name: 'date', type: 'date' },
+          { name: 'receiptUrl', type: 'varchar', isNullable: true },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+          { name: 'updated_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('condo_expenses');
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931400000-create-table-apartments.ts
+++ b/src/shared/providers/typeorm/migrations/1744931400000-create-table-apartments.ts
@@ -1,0 +1,21 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTableApartments1744931400000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'apartments',
+        columns: [
+          { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+          { name: 'number', type: 'varchar' },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+          { name: 'updated_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('apartments');
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931500000-create-table-users.ts
+++ b/src/shared/providers/typeorm/migrations/1744931500000-create-table-users.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTableUsers1744931500000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'users',
+        columns: [
+          { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+          { name: 'name', type: 'varchar' },
+          { name: 'email', type: 'varchar' },
+          { name: 'password', type: 'varchar' },
+          { name: 'phone', type: 'varchar' },
+          { name: 'isAdmin', type: 'bit', default: 0 },
+          { name: 'apartmentId', type: 'int' },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+          { name: 'updated_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['apartmentId'],
+            referencedTableName: 'apartments',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('users');
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931600000-create-table-expense-approvals.ts
+++ b/src/shared/providers/typeorm/migrations/1744931600000-create-table-expense-approvals.ts
@@ -1,0 +1,37 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateTableExpenseApprovals1744931600000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'expense_approvals',
+        columns: [
+          { name: 'id', type: 'int', isPrimary: true, isGenerated: true, generationStrategy: 'increment' },
+          { name: 'expenseId', type: 'int' },
+          { name: 'userId', type: 'int' },
+          { name: 'created_at', type: 'datetime', default: 'CURRENT_TIMESTAMP' },
+        ],
+        foreignKeys: [
+          {
+            columnNames: ['expenseId'],
+            referencedTableName: 'condo_expenses',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+          {
+            columnNames: ['userId'],
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            onDelete: 'CASCADE',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('expense_approvals');
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931700000-alter-condo-expenses-add-pix-approvals.ts
+++ b/src/shared/providers/typeorm/migrations/1744931700000-alter-condo-expenses-add-pix-approvals.ts
@@ -1,0 +1,23 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AlterCondoExpensesAddPixApprovals1744931700000
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumns('condo_expenses', [
+      new TableColumn({ name: 'pixKey', type: 'varchar', isNullable: true }),
+      new TableColumn({ name: 'approvalsRequired', type: 'int', default: 0 }),
+      new TableColumn({ name: 'paid', type: 'bit', default: 0 }),
+      new TableColumn({ name: 'paidByUserId', type: 'int', isNullable: true }),
+      new TableColumn({ name: 'paidByApartmentId', type: 'int', isNullable: true }),
+    ]);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('condo_expenses', 'paidByApartmentId');
+    await queryRunner.dropColumn('condo_expenses', 'paidByUserId');
+    await queryRunner.dropColumn('condo_expenses', 'paid');
+    await queryRunner.dropColumn('condo_expenses', 'approvalsRequired');
+    await queryRunner.dropColumn('condo_expenses', 'pixKey');
+  }
+}

--- a/src/shared/providers/typeorm/migrations/1744931800000-alter-condo-fees-add-apartment.ts
+++ b/src/shared/providers/typeorm/migrations/1744931800000-alter-condo-fees-add-apartment.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner, TableColumn, TableForeignKey } from 'typeorm';
+
+export class AlterCondoFeesAddApartment1744931800000 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'condo_fees',
+      new TableColumn({ name: 'apartmentId', type: 'int' }),
+    );
+    await queryRunner.createForeignKey(
+      'condo_fees',
+      new TableForeignKey({
+        columnNames: ['apartmentId'],
+        referencedTableName: 'apartments',
+        referencedColumnNames: ['id'],
+        onDelete: 'CASCADE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    const table = await queryRunner.getTable('condo_fees');
+    const foreignKey = table?.foreignKeys.find((fk) => fk.columnNames.includes('apartmentId'));
+    if (foreignKey) {
+      await queryRunner.dropForeignKey('condo_fees', foreignKey);
+    }
+    await queryRunner.dropColumn('condo_fees', 'apartmentId');
+  }
+}


### PR DESCRIPTION
## Summary
- link condo fees to apartments and generate annual fees for each unit
- add resident endpoints to summarize pending condo fees and list apartment debts
- switch database configuration and migrations from MSSQL to MySQL
- document controller responses with ApiResponse metadata and dedicated DTOs

## Testing
- `npm run lint` *(fails: simple-import-sort/imports and other existing lint errors)*
- `npm run typecheck` *(fails: middleware type mismatches and express typings issues)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf774637008330a012774f31c73539